### PR TITLE
Adding explicit solc 0.4.17

### DIFF
--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,4 +1,22 @@
 module.exports = {
   // See <http://truffleframework.com/docs/advanced/configuration>
   // to customize your Truffle configuration!
+  networks: {
+    development: {
+      host: "127.0.0.1",
+      port: "7545",
+      network_id: "*" // match any network id
+    },
+    rinkeby: {
+      host: "localhost",
+      port: 8545,
+      network_id: 4,
+      gas: 4700000
+    }
+  },
+  compilers: {
+    solc: {
+      version: "0.4.17"
+    }
+  }
 };

--- a/truffle.js
+++ b/truffle.js
@@ -13,5 +13,10 @@ module.exports = {
       network_id: 4,
       gas: 4700000
     }
+  },
+  compilers: {
+    solc: {
+      version: "0.4.17"
+    }
   }
 };


### PR DESCRIPTION
Added solc 0.4.17 explictly in the compilers section of both truffle.js and truffle-config.js.

I'm not sure this was the best way to do it, but it was a quick way to make the project work-out of the box with:

Truffle v5.1.42 (core: 5.1.42)
Solidity v0.5.16 (solc-js)
Node v14.4.0
Web3.js v1.2.1

