### PR TITLE
Update DappTokenSale.sol

### DIFF
--- a/contracts/DappTokenSale.sol
+++ b/contracts/DappTokenSale.sol
@@ -16,8 +16,8 @@ contract DappTokenSale {
         tokenPrice = _tokenPrice;
     }
 
-    function multiply(uint x, uint y) internal pure returns (uint z) {
-        require(y == 0 || (z = x * y) / y == x);
+    function multiply(uint x, uint y) internal view returns (uint z) {
+        require(y == tokenPrice || (z = x * y) / y == x);
     }
 
     function buyTokens(uint256 _numberOfTokens) public payable {


### PR DESCRIPTION
Pure was being used but since we pass the token price on deployment it has to be set has view. Also y == 0 was not passing. Y should be tokenPrice. Tested it in Remix with solidity v0.7.0 and everything is working.